### PR TITLE
Fix misleading function name

### DIFF
--- a/ina3221.c
+++ b/ina3221.c
@@ -286,7 +286,7 @@ esp_err_t ina3221_set_warning_alert(ina3221_t *dev, ina3221_channel_t channel, f
     return write_reg_16(dev, INA3221_REG_WARNING_ALERT_1 + channel * 2, *(uint16_t *)&raw);
 }
 
-esp_err_t ina3221_set_sum_warning_alert(ina3221_t *dev, float voltage)
+esp_err_t ina3221_set_sum_critical_alert(ina3221_t *dev, float voltage)
 {
     CHECK_ARG(dev);
 

--- a/ina3221.h
+++ b/ina3221.h
@@ -344,7 +344,7 @@ esp_err_t ina3221_set_critical_alert(ina3221_t *dev, ina3221_channel_t channel, 
 esp_err_t ina3221_set_warning_alert(ina3221_t *dev, ina3221_channel_t channel, float current);
 
 /**
- * @brief Set Sum Warning alert
+ * @brief Set Sum Critical alert
  *
  * Compared to each completed cycle of all selected channels : Sum register
  *
@@ -352,7 +352,7 @@ esp_err_t ina3221_set_warning_alert(ina3221_t *dev, ina3221_channel_t channel, f
  * @param voltage voltage to set (mV) //  max : 655.32
  * @return ESP_OK to indicate success
  */
-esp_err_t ina3221_set_sum_warning_alert(ina3221_t *dev, float voltage);
+esp_err_t ina3221_set_sum_critical_alert(ina3221_t *dev, float voltage);
 
 /**
  * @brief Set Power-valid upper-limit


### PR DESCRIPTION
The ina3221's summation limit register triggers the 'Critcal Alert' pin, not the 'Warning Alert' pin.

Change the function name and documentation to reflect this.

Reference:
INA3221 datasheet:  7.3.2.1.1 Summation Control Function
[https://www.ti.com/lit/ds/symlink/ina3221.pdf#page=12](https://www.ti.com/lit/ds/symlink/ina3221.pdf#page=12)

> The INA3221 also allows the **Critical alert pin** to be controlled by the summation control function. This function
> adds the **single shunt-voltage conversions** for the desired channels (set by SCC1-3 in the Mask/Enable register)
> to compare the combined sum to the programmed limit.
> The SCC bits either disable the summation control function or allow the summation control function to switch
> between including two or three channels in the Shunt-Voltage Sum register. The Shunt-Voltage Sum Limit
> register contains the programmed value that is compared to the value in the Shunt-Voltage Sum register to
> determine if the total summed limit is exceeded. **If the shunt-voltage sum limit value is exceeded, the Critical
> alert pin pulls low.** Either the summation alert flag indicator bit (SF) or the individual critical alert limit bits (CF1-3)
> in the Mask/Enable register determine the source of the alert when the Critical alert pin pulls low.
> For the summation limit to have a meaningful value, use the same shunt-resistor value on all included channels.
> Unless equal shunt-resistor values are used for each channel, do not use this function to add the individual
> conversion values directly together in the Shunt-Voltage Sum register to report the total current.

